### PR TITLE
Cli help

### DIFF
--- a/src/main/java/legends/Application.java
+++ b/src/main/java/legends/Application.java
@@ -115,7 +115,7 @@ public class Application {
 				System.exit(0);
 			}
     } catch (UnrecognizedOptionException e) {
-      LOG.error("Unrecognized exception: " + e.getOption());
+      LOG.error("Unrecognized option: " + e.getOption());
       formatter.printHelp("legends", options);
       System.exit(1);
 		} catch (ParseException e) {

--- a/src/main/java/legends/Application.java
+++ b/src/main/java/legends/Application.java
@@ -89,7 +89,7 @@ public class Application {
 		options.addOption("w", "world", true, "path to legends.xml or archive");
 		options.addOption("p", "port", true, "use specific port");
 		options.addOption("u", "subUri", true, "run on /<subUri>");
-    options.addOption("h", "help", false, "display this help and exit");
+		options.addOption("h", "help", false, "display this help and exit");
 
 		HelpFormatter formatter = new HelpFormatter();
 
@@ -97,10 +97,10 @@ public class Application {
 			CommandLineParser parser = new DefaultParser();
 			CommandLine cmd = parser.parse(options, args);
 
-      if (cmd.hasOption("help")) {
-        formatter.printHelp("legends", options);
-        System.exit(0);
-      }
+			if (cmd.hasOption("help")) {
+				formatter.printHelp("legends", options);
+				System.exit(0);
+			}
 
 			subUri = cmd.getOptionValue("subUri");
 			port = cmd.hasOption("port") ? Integer.parseInt(cmd.getOptionValue("port")) : null;
@@ -114,10 +114,10 @@ public class Application {
 				LOG.warn("you need to specify a world if running in server mode");
 				System.exit(0);
 			}
-    } catch (UnrecognizedOptionException e) {
-      LOG.error("Unrecognized option: " + e.getOption());
-      formatter.printHelp("legends", options);
-      System.exit(1);
+		} catch (UnrecognizedOptionException e) {
+			LOG.error("Unrecognized option: " + e.getOption());
+			formatter.printHelp("legends", options);
+			System.exit(1);
 		} catch (ParseException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/legends/Application.java
+++ b/src/main/java/legends/Application.java
@@ -15,6 +15,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.velocity.app.Velocity;
@@ -88,13 +89,18 @@ public class Application {
 		options.addOption("w", "world", true, "path to legends.xml or archive");
 		options.addOption("p", "port", true, "use specific port");
 		options.addOption("u", "subUri", true, "run on /<subUri>");
+    options.addOption("h", "help", false, "display this help and exit");
 
 		HelpFormatter formatter = new HelpFormatter();
-		formatter.printHelp("legends", options);
 
 		try {
 			CommandLineParser parser = new DefaultParser();
 			CommandLine cmd = parser.parse(options, args);
+
+      if (cmd.hasOption("help")) {
+        formatter.printHelp("legends", options);
+        System.exit(0);
+      }
 
 			subUri = cmd.getOptionValue("subUri");
 			port = cmd.hasOption("port") ? Integer.parseInt(cmd.getOptionValue("port")) : null;
@@ -108,7 +114,10 @@ public class Application {
 				LOG.warn("you need to specify a world if running in server mode");
 				System.exit(0);
 			}
-
+    } catch (UnrecognizedOptionException e) {
+      LOG.error("Unrecognized exception: " + e.getOption());
+      formatter.printHelp("legends", options);
+      System.exit(1);
 		} catch (ParseException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
I changed how the help is displayed to make it more consistent with other CLI application.

The default help printing on program starting was removed.

A --help option was added which displays the help and exits the program.

I case of unrecognized option, an error message is displayed with the help, and the program exits.