### PR TITLE
fix range date for entity leader still active

### DIFF
--- a/src/main/resources/templates/entity.vm
+++ b/src/main/resources/templates/entity.vm
@@ -84,7 +84,12 @@
 				</tr></thead>
 				#foreach( $leader in $entity.leaders )
 				<tr>
-					<td nowrap>from $leader.from till $leader.till</td>
+					<td nowrap>
+						#if($leader.till >= 0)
+							from $leader.from till $leader.till</td>
+						#else
+							since $leader.from
+						#end
 					<td nowrap>$leader.position</td>
 					<td>$leader.hf.link</td>
 				</tr>


### PR DESCRIPTION
Some leaders have a **til** attribute of -1 when there are still in activity.

I changed the template to better show this.