### PR TITLE
Add relationship type "source of information"

### DIFF
--- a/src/main/java/legends/model/HistoricalFigure.java
+++ b/src/main/java/legends/model/HistoricalFigure.java
@@ -62,7 +62,7 @@ public class HistoricalFigure extends AbstractObject {
 	private List<EntitySquadLink> entitySquadLinks = new ArrayList<>();
 	@Xml(value = "entity_former_squad_link", elementClass = EntitySquadLink.class, multiple = true)
 	private List<EntitySquadLink> entityFormerSquadLinks = new ArrayList<>();
-	@Xml(value = "relationship_profile_hf", elementClass = RelationshipProfile.class, multiple = true)
+	@Xml(value = "relationship_profile_hf_visual", elementClass = RelationshipProfile.class, multiple = true)
 	private List<RelationshipProfile> relationshipProfiles = new ArrayList<>();
 
 	@Xml(value = "goal", elementClass = String.class, multiple = true)

--- a/src/main/java/legends/model/RelationshipProfile.java
+++ b/src/main/java/legends/model/RelationshipProfile.java
@@ -21,6 +21,8 @@ public class RelationshipProfile {
 	private int repTradePartner = -1;
 	@Xml("rep_bonded")
 	private int repBonded = -1;
+	@Xml("rep_information_source")
+	private int repInformationSource = -1;
 
 	public int getHfId() {
 		return hfId;
@@ -94,17 +96,27 @@ public class RelationshipProfile {
 		this.repBonded = repBonded;
 	}
 
+	public int getRepInformationSource() {
+		return repInformationSource;
+	}
+
+	public void setRepInformationSource(int repInformationSource) {
+		this.repInformationSource = repInformationSource;
+	}
+
 	public String getType() {
 		if (repBonded > 0)
-			return "Lover";
+			return "lover";
 		if (repBuddy > 0)
-			return "Friend";
+			return "friend";
 		if (repFriendly > 0)
-			return "Friendly Terms";
+			return "friendly terms";
 		if (repQuarreler > 0)
-			return "Quarreler";
+			return "quarreler";
 		if (repTradePartner > 0)
-			return "Trade Partner";
+			return "trade partner";
+		if (repInformationSource > 0)
+			return "source of information";
 
 		return "unknown";
 	}


### PR DESCRIPTION
Fixed name of tag <relationship_profile_hf>  ->  <relationship_profile_hf_visual>
(broken since before DF 0.44 ?)
Add support for relationship type tag: 'rep_information_source'.
