### PR TITLE
map: use field 'rectangle' instead of 'coords' for positioning sites

### DIFF
--- a/src/main/java/legends/model/Site.java
+++ b/src/main/java/legends/model/Site.java
@@ -13,9 +13,11 @@ import legends.model.events.HfDestroyedSiteEvent;
 import legends.model.events.basic.Coords;
 import legends.model.events.basic.Event;
 import legends.model.events.basic.Filters;
+import legends.model.events.basic.Rectangle;
 import legends.xml.annotation.Xml;
 import legends.xml.annotation.XmlConverter;
 import legends.xml.converter.CoordsConverter;
+import legends.xml.converter.RectangleConverter;
 
 public class Site extends AbstractObject {
 	@Xml("name")
@@ -27,6 +29,10 @@ public class Site extends AbstractObject {
 	@Xml("coords")
 	@XmlConverter(CoordsConverter.class)
 	private Coords coords;
+
+	@Xml("rectangle")
+	@XmlConverter(RectangleConverter.class)
+	private Rectangle rectangle;
 
 	private List<Structure> structures = new ArrayList<>();
 	private List<SiteProperty> siteProperties = new ArrayList<>();
@@ -68,6 +74,30 @@ public class Site extends AbstractObject {
 		if(coords == null)
 			return -1;
 		return coords.getY();
+	}
+
+	public float getX1() {
+		if(rectangle == null)
+			return -1;
+		return (float)rectangle.getX1() / 16;
+	}
+
+	public float getY1() {
+		if(rectangle == null)
+			return -1;
+		return (float)rectangle.getY1() / 16 - 1;
+	}
+
+	public float getX2() {
+		if(rectangle == null)
+			return -1;
+		return (float)rectangle.getX2() / 16;
+	}
+
+	public float getY2() {
+		if(rectangle == null)
+			return -1;
+		return (float)rectangle.getY2() / 16 - 1;
 	}
 
 	@Xml(value = "structures", element = "structure", elementClass = Structure.class)

--- a/src/main/java/legends/model/events/basic/Rectangle.java
+++ b/src/main/java/legends/model/events/basic/Rectangle.java
@@ -1,0 +1,40 @@
+package legends.model.events.basic;
+
+public class Rectangle {
+	private int x1;
+	private int y1;
+	private int x2;
+	private int y2;
+
+	public Rectangle(String value) {
+		String[] coords = value.split("[,:]");
+		x1 = Integer.parseInt(coords[0]);
+		y1 = Integer.parseInt(coords[1]);
+		x2 = Integer.parseInt(coords[2]);
+		y2 = Integer.parseInt(coords[3]);
+	}
+	
+	public int getX1() {
+		return x1;
+	}
+
+	public int getY1() {
+		return y1;
+	}
+	
+	public int getX2() {
+		return x2;
+	}
+
+	public int getY2() {
+		return y2;
+	}
+	
+	public int getWidth() {
+		return x2 - x1;
+	}
+
+	public int getHeight() {
+		return y2 - y1;
+	}
+}

--- a/src/main/java/legends/xml/converter/RectangleConverter.java
+++ b/src/main/java/legends/xml/converter/RectangleConverter.java
@@ -1,0 +1,10 @@
+package legends.xml.converter;
+
+import legends.model.events.basic.Rectangle;
+
+public class RectangleConverter implements ValueConverter {
+	@Override
+	public Object convert(String value) {
+		return new Rectangle(value);
+	}
+}

--- a/src/main/resources/templates/collection.vm
+++ b/src/main/resources/templates/collection.vm
@@ -13,10 +13,10 @@ $(function() {
 		#set($defender = $World.getEntity($event.defenderEntId))
 
 		#foreach($site in $aggressor.sites)
-			addSite('$site.link', $site.x, $site.y, '$aggressor.color');
+			addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '$aggressor.color', '$site.glyph');
 		#end
 		#foreach($site in $defender.sites)
-			addSite('$site.link', $site.x, $site.y, '$defender.color');
+			addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '$defender.color', '$site.glyph');
 		#end
 		#foreach( $e in $event.historicalEventCollections )
 			#if($e.type.equals("battle"))
@@ -32,10 +32,10 @@ $(function() {
 		#set($defender = $World.getEntity($war.defenderEntId))
 
 		#foreach($site in $aggressor.sites)
-			addSite('$site.link', $site.x, $site.y, '$aggressor.color');
+			addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '$aggressor.color', '$site.glyph');
 		#end
 		#foreach($site in $defender.sites)
-			addSite('$site.link', $site.x, $site.y, '$defender.color');
+			addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '$defender.color', '$site.glyph');
 		#end
 		addBattle('$event.link', $event.location.coords.x, $event.location.coords.y);
 		zoom();

--- a/src/main/resources/templates/entity.vm
+++ b/src/main/resources/templates/entity.vm
@@ -18,7 +18,7 @@
 #parse("map.vm")
 <script>
 #foreach($site in $entity.sites)
-	addSite('$site.link', $site.x, $site.y, '$entity.color');
+	addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '$entity.color', '$site.glyph');
 #end
 
 #if($entity.claims.size()==-1)

--- a/src/main/resources/templates/index.vm
+++ b/src/main/resources/templates/index.vm
@@ -67,7 +67,7 @@
 				#foreach($entity in $entities)
 					// $entity.name
 					#foreach($site in $entity.sites)
-						addSite('$site.link', $site.x, $site.y, '$entity.color');
+						addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '$entity.color', '$site.glyph');
 					#end
 				#end
 			#end	

--- a/src/main/resources/templates/map.vm
+++ b/src/main/resources/templates/map.vm
@@ -89,13 +89,24 @@
 		return [ coordO(y,x,o,o), coordO(y,x,1-o,o), coordO(y,x,1-o,1-o), coordO(y,x,o,1-o) ];
 	}
 	
-	function addSite(name, y, x, color) {
-		var polygon = L.polygon( square(y, x, siteOffset), {
-					color : color,
-					opacity: 1, fillOpacity: 0.7,
-					weight : 3
-				}).addTo(sitesLayer);
-
+	function addSite(name, y1, x1, y2, x2, color, glyph) {
+		/* resize tiny sites like lairs */
+		var MIN_SIZE = .3;
+		if (y2-y1 < MIN_SIZE) {
+			y1 = (y1+y2)/2 - MIN_SIZE/2;
+			y2 = y1 + MIN_SIZE;
+		}
+		if (x2-x1 < MIN_SIZE) {
+			x1 = (x1+x2)/2 - MIN_SIZE/2;
+			x2 = x1 + MIN_SIZE;
+		}
+		/* TODO: use glyph of the site instead of a polygon? */
+		var polygon = L.polygon(
+			[ coord(y1, x1), coord(y2, x1), coord(y2, x2), coord(y1, x2) ], {
+				color : color,
+				opacity: 1, fillOpacity: 0.7,
+				weight : 3
+			}).addTo(sitesLayer);
 		polygon.bindPopup(name);
 	}
 	

--- a/src/main/resources/templates/mountain.vm
+++ b/src/main/resources/templates/mountain.vm
@@ -6,7 +6,7 @@
 </div>
 <script>
 		$(function() {
-				addSite('$mountain.link', $mountain.coords.x, $mountain.coords.y, '#FFF');
+				addSite('$mountain.link', $mountain.coords.x, $mountain.coords.y, '#FFF', '$mountain.glyph');
 		});
 	</script>
 

--- a/src/main/resources/templates/site.vm
+++ b/src/main/resources/templates/site.vm
@@ -16,7 +16,7 @@
 </div>
 #parse("map.vm")
 <script>
-	addSite('$site.link', $site.x, $site.y, '#F0F');
+	addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '#F0F', '$site.glyph');
 	zoomTo($site.x, $site.y, 4);
 </script>
 

--- a/src/main/resources/templates/structure.vm
+++ b/src/main/resources/templates/structure.vm
@@ -7,7 +7,7 @@
 <script>
 		$(function() {
 			#set($site=$World.getSite($structure.siteId))
-			addSite('$site.link', $site.x, $site.y, '#FFF');
+			addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '#FFF', '$site.glyph');
 			zoomTo($site.x, $site.y, 4);
 		});
 	</script>

--- a/src/main/resources/templates/worldMap.vm
+++ b/src/main/resources/templates/worldMap.vm
@@ -29,7 +29,7 @@
 			#end
 			
 			#foreach($site in $World.getSites())
-				addSite('$site.link', $site.x, $site.y, '#if($site.owner.root)$site.owner.root.color#else#CCC#end');
+				addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '#if($site.owner.root)$site.owner.root.color#else#CCC#end', '$site.glyph');
 			#end
 			
 			#foreach($wc in $World.getPointWorldConstructions())

--- a/src/main/resources/templates/worldconstruction.vm
+++ b/src/main/resources/templates/worldconstruction.vm
@@ -7,7 +7,7 @@
 <script>
 		$(function() {
 			#foreach($site in $wc.sites)
-				addSite('$site.link', $site.x, $site.y, '#FF0');
+				addSite('$site.link', $site.x1, $site.y1, $site.x2, $site.y2, '#FF0', '$site.glyph');
 			#end
 			
 			#if($wc.master)


### PR DESCRIPTION
Fix for #28:
Small squares are lairs, castles, towers ... etc
remark: roads, bridges, mountains still use the old (less accurate) positioning system.

Before:
![before](https://user-images.githubusercontent.com/18101705/76263528-6ab6c700-625f-11ea-935d-3aff0c9094cc.png)

After:
![after](https://user-images.githubusercontent.com/18101705/76263548-74d8c580-625f-11ea-9100-ada829ae1421.png)
