### PR TITLE
world map: taint 'evil' and 'good' regions purple and blue

### DIFF
--- a/src/main/java/legends/model/Region.java
+++ b/src/main/java/legends/model/Region.java
@@ -19,6 +19,9 @@ public class Region extends AbstractObject {
 	@Xml("type")
 	private String type;
 
+	@Xml("evilness")
+	private String evilness = "neutral";
+
 	@Xml("coords")
 	@XmlConverter(CoordListConverter.class)
 	private List<Coords> coords = new ArrayList<>();
@@ -39,6 +42,14 @@ public class Region extends AbstractObject {
 		this.type = type;
 	}
 
+	public String getEvilness() {
+		return evilness;
+	}
+
+	public void setEvilness(String evilness) {
+		this.evilness = evilness;
+	}
+
 	public List<Coords> getCoords() {
 		return coords;
 	}
@@ -57,7 +68,11 @@ public class Region extends AbstractObject {
 	}
 	
 	public String getMapDescription() {
-		return getLink() + "<br/><span>" + type + "</span>";
+		String description = getLink() + "<br/><span>" + type;
+		if (! evilness.contains("neutral")) {
+			description += " ("+evilness+")";
+		}
+		return description + "</span>";
 	}
 
 	class Line {

--- a/src/main/resources/templates/map.vm
+++ b/src/main/resources/templates/map.vm
@@ -5,12 +5,13 @@
 	var landmassesLayer = L.layerGroup();
 	var regionsLayer = L.layerGroup();
 	var mountainsLayer = L.layerGroup();
+	var evilnessLayer = L.layerGroup();
 
 	var map = L.map('map', {
 		maxZoom : 6,
 		minZoom : 0,
 		crs : L.CRS.Simple,
-		layers: [sitesLayer, constructionsLayer, mountainsLayer]
+		layers: [sitesLayer, constructionsLayer, mountainsLayer, evilnessLayer]
 	});
 
 	
@@ -49,7 +50,8 @@
 		    "World Constructions": constructionsLayer,
 		    "Mountain Peaks": mountainsLayer,
 		    "Landmasses": landmassesLayer,
-		    "Regions": regionsLayer
+		    "Regions": regionsLayer,
+		    "Evilness": evilnessLayer,
 		};
 	
 	#if($layerControl)

--- a/src/main/resources/templates/worldMap.vm
+++ b/src/main/resources/templates/worldMap.vm
@@ -58,8 +58,26 @@
 	   			polygon.on('mouseout', function (e) {
 	   	         	this.setStyle({ weight: 3});
 	   	        });
+	   	        
+				#if($region.evilness == 'evil')
+					var fillColor = 'fuchsia';
+				#elseif($region.evilness == 'good')
+					var fillColor = 'aqua';
+				#else
+					var fillColor = 'transparent';
+				#end
+	   	        if (fillColor != 'transparent') {
+					var evilPolygon = L.polygon(
+						polygon.getLatLngs(),
+						{ 	color: 'transparent',
+							opacity: 1,
+							fillColor: fillColor,
+							fillOpacity: .3,
+							interactive: false,
+						});
+	   	        	evilPolygon.addTo(evilnessLayer);
+	   	        }
 			#end
-			
 		});
 	</script>
 


### PR DESCRIPTION
fix for #63: add an extra layer 'evilness' on the World Map that exploits the new region property <evilness> from legends_plus (dfhack-0.47.04-beta1)