### PR TITLE
Fix for #65: support for new format of interaction_action and secret_text

### DIFF
--- a/src/main/java/legends/model/events/HfDoesInteractionEvent.java
+++ b/src/main/java/legends/model/events/HfDoesInteractionEvent.java
@@ -106,24 +106,37 @@ public class HfDoesInteractionEvent extends Event implements LocalEvent, HfRelat
 		String doer = World.getHistoricalFigure(doerHfId).getLink();
 		String target = World.getHistoricalFigure(targetHfId).getLink();
 
-		if (interactionAction != null || interactionString != null) {
-			String[] action = interactionAction.substring(1, interactionAction.length() - 1).split(":");
-			String[] string = interactionString.substring(1, interactionString.length() - 1).split(":");
-
-			String s1 = "";
-			String s2 = "";
-			if (action[0].equals("IS_HIST_STRING_1"))
-				s1 = action[1];
-			if (action[0].equals("IS_HIST_STRING_2")) {
-				s1 = " bit ";
-				s2 = action[1];
+		if (interactionAction != null) {
+			if (interactionString == null) {
+				// since dfhack 0.47.04-r1
+				if (interactionAction.startsWith("bit") && interactionAction.length()>3) {
+					return doer + " bit " + target + interactionAction.substring(3);
+				}
+				if (interactionAction.startsWith("cursed") && interactionAction.length()>6) {
+					return doer + " cursed " + target + interactionAction.substring(6);
+				}
+				return doer + " interacted with " + target;
 			}
-			if (string[0].equals("IS_HIST_STRING_1"))
-				s1 = string[1];
-			if (string[0].equals("IS_HIST_STRING_2"))
-				s2 = string[1];
-
-			return doer + s1 + target + s2;
+			else {
+				// before dfhack 0.47.04-r1
+				String[] action = interactionAction.substring(1, interactionAction.length() - 1).split(":");
+				String[] string = interactionString.substring(1, interactionString.length() - 1).split(":");
+	
+				String s1 = "";
+				String s2 = "";
+				if (action[0].equals("IS_HIST_STRING_1"))
+					s1 = action[1];
+				if (action[0].equals("IS_HIST_STRING_2")) {
+					s1 = " bit ";
+					s2 = action[1];
+				}
+				if (string[0].equals("IS_HIST_STRING_1"))
+					s1 = string[1];
+				if (string[0].equals("IS_HIST_STRING_2"))
+					s2 = string[1];
+	
+				return doer + s1 + target + s2;
+			}
 		}
 
 		if (interaction.startsWith("DEITY_CURSE_WEREBEAST_"))

--- a/src/main/java/legends/model/events/HfLearnsSecretEvent.java
+++ b/src/main/java/legends/model/events/HfLearnsSecretEvent.java
@@ -76,8 +76,11 @@ public class HfLearnsSecretEvent extends Event implements HfRelatedEvent, Artifa
 		String secret = "the secrets of life and death";
 		if (!interaction.startsWith("SECRET_"))
 			secret = interaction;
-		if (secretText != null)
+		if (secretText.contains(":"))
+			// before dfhack 0.47.04-r1
 			secret = secretText.substring(1, secretText.length() - 1).split(":")[1];
+		if (secretText != null)
+			secret = secretText;
 		if (teacherHfId != -1)
 			return World.getHistoricalFigure(teacherHfId).getLink() + " taught " + student + " " + secret;
 		if (artifactId != -1)


### PR DESCRIPTION
Fix for #65: support new export format of interaction_action and secret_text since dfhack-0.47.04-r1