### PR TITLE
Handle changes of types in legends_plus

### DIFF
--- a/src/main/java/legends/model/events/BodyAbusedEvent.java
+++ b/src/main/java/legends/model/events/BodyAbusedEvent.java
@@ -22,8 +22,8 @@ public class BodyAbusedEvent extends HfEvent implements EntityRelatedEvent, HfRe
 	@Xml("civ")
 	private int civId = -1;
 	@Xml(value = "abuse_type", track = true)
-	private int abuseType = -1;
-	@XmlComponent(prefix = "props_")
+	private String abuseType = "abused";
+	@XmlComponent
 	private Item item = new Item();
 	@Xml("props_pile_type")
 	private int pileType = -1;
@@ -38,11 +38,11 @@ public class BodyAbusedEvent extends HfEvent implements EntityRelatedEvent, HfRe
 		this.civId = civId;
 	}
 
-	public int getAbuseType() {
+	public String getAbuseType() {
 		return abuseType;
 	}
 
-	public void setAbuseType(int abuseType) {
+	public void setAbuseType(String abuseType) {
 		this.abuseType = abuseType;
 	}
 
@@ -79,7 +79,7 @@ public class BodyAbusedEvent extends HfEvent implements EntityRelatedEvent, HfRe
 		String hf = World.getHistoricalFigure(hfId).getLink();
 		String body = bodies.stream().map(World::getHistoricalFigure).collect(EventHelper.hfList());
 
-		String item = this.item.getText();
+		String item = EventHelper.prependIndefiniteArticle(this.item.getText());
 
 		String s1 = "body";
 		String s2 = " was";
@@ -89,18 +89,16 @@ public class BodyAbusedEvent extends HfEvent implements EntityRelatedEvent, HfRe
 		}
 
 		switch (abuseType) {
-		case -1:
+		case "impaled":
 			return "the " + s1 + " of " + body + s2 + " impaled on " + item + " by " + civ + location.getLink("in");
-		case 0:
-			return "the " + s1 + " of " + body + s2 + " impaled on " + item + " by " + civ + location.getLink("in");
-		case 1:
+		case "piled":
 			return "the " + s1 + " of " + body + s2 + " added to a gruesome sculpture by " + civ
 					+ location.getLink("in");
-		case 3:
+		case "hung":
 			return "the " + s1 + " of " + body + s2 + " hung from a tree by " + civ + location.getLink("in");
-		case 4:
+		case "mutilated":
 			return "the " + s1 + " of " + body + s2 + " horribly mutilated by " + civ + location.getLink("in");
-		case 5:
+		case "animated":
 			return "the " + s1 + " of " + body + s2 + " animated" + (hfId != -1 ? " by " + hf : "")
 					+ location.getLink("in");
 		default:

--- a/src/main/java/legends/model/events/CreateEntityPositionEvent.java
+++ b/src/main/java/legends/model/events/CreateEntityPositionEvent.java
@@ -13,7 +13,7 @@ public class CreateEntityPositionEvent extends HfEvent implements EntityRelatedE
 	@Xml("site_civ")
 	private int siteCivId = -1;
 	@Xml(value = "reason", track = true)
-	private int reason = -1;
+	private String reason = "reason";
 	@Xml("position")
 	private String position;
 
@@ -33,11 +33,11 @@ public class CreateEntityPositionEvent extends HfEvent implements EntityRelatedE
 		this.siteCivId = siteCivId;
 	}
 
-	public int getReason() {
+	public String getReason() {
 		return reason;
 	}
 
-	public void setReason(int reason) {
+	public void setReason(String reason) {
 		this.reason = reason;
 	}
 
@@ -61,15 +61,15 @@ public class CreateEntityPositionEvent extends HfEvent implements EntityRelatedE
 			hf = World.getHistoricalFigure(hfId).getLink() + " of ";
 		String civ = World.getEntity(civId).getLink();
 		switch (reason) {
-		case 0:
+		case "force_of_argument":
 			return hf + civ + " created the position of " + position + " trough force of argument";
-		case 1:
+		case "threat_of_violence":
 			return hf + civ + " compelled the creation of the position of " + position + " with threats of violence";
-		case 2:
+		case "collaboration":
 			return "members of " + civ + " collaborated to create the position of " + position;
-		case 3:
+		case "wave_of_popular_support":
 			return hf + civ + " created the position of " + position + ", pushed by a wave of popular support";
-		case 4:
+		case "as_a_matter_of_course":
 			return hf + civ + " created the position of " + position + " as a matter of course";
 		default:
 		}

--- a/src/main/java/legends/model/events/EntityPrimaryCriminalsEvent.java
+++ b/src/main/java/legends/model/events/EntityPrimaryCriminalsEvent.java
@@ -18,7 +18,7 @@ public class EntityPrimaryCriminalsEvent extends Event
 	@Xml("structure,structure_id")
 	private int structureId = -1;
 	@Xml(value = "action", track = true)
-	private int action = -1;
+	private String action = "UNKNOWN ACTION";
 
 	public int getEntityId() {
 		return entityId;
@@ -44,11 +44,11 @@ public class EntityPrimaryCriminalsEvent extends Event
 		this.structureId = structureId;
 	}
 
-	public int getAction() {
+	public String getAction() {
 		return action;
 	}
 
-	public void setAction(int action) {
+	public void setAction(String action) {
 		this.action = action;
 	}
 

--- a/src/main/java/legends/model/events/EntityRelocateEvent.java
+++ b/src/main/java/legends/model/events/EntityRelocateEvent.java
@@ -9,7 +9,7 @@ import legends.xml.annotation.Xml;
 import legends.xml.annotation.XmlSubtype;
 
 @XmlSubtype("entity relocate")
-public class EntityReloacateEvent extends Event implements SiteRelatedEvent, EntityRelatedEvent, StructureRelatedEvent {
+public class EntityRelocateEvent extends Event implements SiteRelatedEvent, EntityRelatedEvent, StructureRelatedEvent {
 	@Xml("entity,entity_id")
 	int entityId = -1;
 	@Xml("site,site_id")

--- a/src/main/java/legends/model/events/EntityRelocateEvent.java
+++ b/src/main/java/legends/model/events/EntityRelocateEvent.java
@@ -17,7 +17,7 @@ public class EntityRelocateEvent extends Event implements SiteRelatedEvent, Enti
 	@Xml("structure,structure_id")
 	int structureId = -1;
 	@Xml(value = "action", track = true)
-	private int action = -1;
+	private String action = "UNKNOWN ACTION";
 
 	public int getEntityId() {
 		return entityId;
@@ -43,11 +43,11 @@ public class EntityRelocateEvent extends Event implements SiteRelatedEvent, Enti
 		this.structureId = structureId;
 	}
 
-	public int getAction() {
+	public String getAction() {
 		return action;
 	}
 
-	public void setAction(int action) {
+	public void setAction(String action) {
 		this.action = action;
 	}
 

--- a/src/main/java/legends/model/events/HfWoundedEvent.java
+++ b/src/main/java/legends/model/events/HfWoundedEvent.java
@@ -23,9 +23,9 @@ public class HfWoundedEvent extends Event implements LocalEvent, HfRelatedEvent 
 	@Xml("body_part")
 	private int bodyPart = -1;
 	@Xml("injury_type")
-	private int injuryType = -1;
+	private String injuryType = "injury";
 	@Xml("part_lost")
-	private int partLost = -1;
+	private boolean partLost = false;
 	@Xml("was_torture")
 	private boolean wasTorture;
 
@@ -72,19 +72,19 @@ public class HfWoundedEvent extends Event implements LocalEvent, HfRelatedEvent 
 		this.bodyPart = bodyPart;
 	}
 
-	public int getInjuryType() {
+	public String getInjuryType() {
 		return injuryType;
 	}
 
-	public void setInjuryType(int injuryType) {
+	public void setInjuryType(String injuryType) {
 		this.injuryType = injuryType;
 	}
 
-	public int getPartLost() {
+	public boolean getPartLost() {
 		return partLost;
 	}
 
-	public void setPartLost(int partLost) {
+	public void setPartLost(boolean partLost) {
 		this.partLost = partLost;
 	}
 


### PR DESCRIPTION
These fields changed type with dfhack-0.47.04-r2 / exportlegends, causing some warnings
- event create_entity_position / field reason
- event hist_figure_wounded / fields injury_type, part_lost (fixed but not used anywhere)
- event body_abused / field abuse_type
- event entity_primary_criminals / field action
- event entity_relocate / field action
